### PR TITLE
Feature/ecbuild35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAK
 install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
 target_include_directories(${PROJECT_NAME} INTERFACE
                             $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
-                            $<INSTALL_INTERFACE:${MODULE_DIR}>)
+                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR}>)
 
 
 ## Export package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,13 @@ ecbuild_add_library( TARGET   gsw
                      SOURCES  ${gsw_src_files}
                     )
 
-## Fortran Modules
-# Fortran module output directory for build and install interfaces uses a
-# per-compiler, per-version module subdirectory to avoid module clashes between compilers/versions
-set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+## Fortran modules
+set(MODULE_DIR ${PROJECT_NAME}/module)
 set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
-install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/${MODULE_DIR})
 target_include_directories(${PROJECT_NAME} INTERFACE
-                                $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
-                                $<INSTALL_INTERFACE:${MODULE_DIR}>)
+                            $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                            $<INSTALL_INTERFACE:${MODULE_DIR}>)
 
 
 ## Export package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,64 +1,17 @@
-cmake_minimum_required( VERSION 3.3.2 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.12 )
 
 project( gsw VERSION 3.0.5 LANGUAGES Fortran )
 
-set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH} )
-
-set( CMAKE_DIRECTORY_LABELS "gsw" )
-
-set( ECBUILD_DEFAULT_BUILD_TYPE Release )
-set( ENABLE_OS_TESTS           OFF CACHE BOOL "Disable OS tests" FORCE )
-set( ENABLE_LARGE_FILE_SUPPORT OFF CACHE BOOL "Disable testing of large file support" FORCE )
-
+## Ecbuild integration
+find_package( ecbuild QUIET )
 include( ecbuild_system NO_POLICY_SCOPE )
-
-ecbuild_requires_macro_version( 2.7 )
-
-################################################################################
-# Project
-################################################################################
-
 ecbuild_declare_project()
-
-ecbuild_enable_fortran( REQUIRED )
-
-################################################################################
-# Dependencies
-################################################################################
-
-
-################################################################################
-# Definitions
-################################################################################
-
-
-################################################################################
-# Export package info
-################################################################################
-
-list( APPEND GSW_TPLS )
-
-set( GSW_INCLUDE_DIRS ${CMAKE_Fortran_MODULE_DIRECTORY} )
-set( GSW_LIBRARIES gsw )
-
-get_directory_property( GSW_DEFINITIONS COMPILE_DEFINITIONS )
-
-foreach( _tpl ${GSW_TPLS} )
-  string( TOUPPER ${_tpl} TPL )
-  list( APPEND GSW_EXTRA_DEFINITIONS   ${${TPL}_DEFINITIONS}  ${${TPL}_TPL_DEFINITIONS}  )
-  list( APPEND GSW_EXTRA_INCLUDE_DIRS  ${${TPL}_INCLUDE_DIRS} ${${TPL}_TPL_INCLUDE_DIRS} )
-  list( APPEND GSW_EXTRA_LIBRARIES     ${${TPL}_LIBRARIES}    ${${TPL}_TPL_LIBRARIES}    )
-endforeach()
-
-################################################################################
-# Sources
-################################################################################
-
-set( GSW_LINKER_LANGUAGE Fortran )
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+set( CMAKE_DIRECTORY_LABELS ${PROJECT_NAME} )
 
 include( gsw_compiler_flags )
-include_directories( ${GSW_INCLUDE_DIRS} )
 
+## Sources
 add_subdirectory(modules)
 add_subdirectory(toolbox)
 add_subdirectory(test)
@@ -68,32 +21,22 @@ list ( APPEND gsw_src_files
     ${gsw_toolbox_files}
 )
 
-if(ECBUILD_INSTALL_FORTRAN_MODULES)
-    install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
-endif()
-
-################################################################################
-# Library
-################################################################################
-
+## Library
 ecbuild_add_library( TARGET   gsw
                      SOURCES  ${gsw_src_files}
-                     LINKER_LANGUAGE ${GSW_LINKER_LANGUAGE}
                     )
 
-target_include_directories( gsw PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>
-)
+## Fortran Modules
+# Fortran module output directory for build and install interfaces uses a
+# per-compiler, per-version module subdirectory to avoid module clashes between compilers/versions
+set(MODULE_DIR module/${PROJECT_NAME}/${CMAKE_Fortran_COMPILER_ID}/${CMAKE_Fortran_COMPILER_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR})
+install(DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR}/ DESTINATION ${MODULE_DIR})
+target_include_directories(${PROJECT_NAME} INTERFACE
+                                $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR}>
+                                $<INSTALL_INTERFACE:${MODULE_DIR}>)
 
 
-################################################################################
-# Finalise configuration
-################################################################################
-
-# prepares a tar.gz of the sources and/or binaries
-ecbuild_install_project( NAME gsw )
-
-# print the summary of the configuration
+## Export package
+ecbuild_install_project( NAME ${PROJECT_NAME} )
 ecbuild_print_summary()

--- a/gsw-import.cmake.in
+++ b/gsw-import.cmake.in
@@ -1,0 +1,11 @@
+# gsw-import.cmake
+
+#Export Fortran compiler version for checking module compatibility
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID @CMAKE_Fortran_COMPILER_ID@)
+set(@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION @CMAKE_Fortran_COMPILER_VERSION@)
+if(NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_ID STREQUAL CMAKE_Fortran_COMPILER_ID
+   OR NOT @PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION VERSION_EQUAL CMAKE_Fortran_COMPILER_VERSION)
+    message(SEND_ERROR "Package @PROJECT_NAME@ provides Fortran modules built with "
+            "${@PROJECT_NAME@_MODULES_Fortran_COMPILER_ID}-${@PROJECT_NAME@_MODULES_Fortran_COMPILER_VERSION} "
+            "but this build for ${PROJECT_NAME} uses incompatible compiler ${CMAKE_Fortran_COMPILER_ID}-${CMAKE_Fortran_COMPILER_VERSION}")
+endif()


### PR DESCRIPTION
## Description

Ecbuild 3.6+ update.
* Correctly detect and initialize ecbuild and set package version 
* Require minimum cmake version 3.12
* Add a `gsw-import.cmake.in` file for transitive dependencies and remove the non-functional `_TPL` variables
* Export fortran modules to `${PACKAGE_NAME}/module`

### Issue(s) addressed

Works with ecbuild 3.6+.  Properly propogates transitive target dependencies with `<pkg>-import.cmake.in`.

## Acceptance Criteria (Definition of Done)

Builds and CTests pass in bundles using new ecbuild3.6 JEDI Stack.

## Dependencies

None.

## Impact

None.

## Test Data

None.