### PR TITLE
change version to 3.0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.12 )
 
-project( gsw VERSION 3.0.6-jedi LANGUAGES Fortran )
+project( gsw VERSION 3.0.6 LANGUAGES Fortran )
 
 ## Ecbuild integration
 find_package( ecbuild QUIET )


### PR DESCRIPTION
I see errors related to GSW version when building jedi-bundle on orion:

> CMake Error at /work/noaa/da/role-da/spack-stack/spack-stack-1.0.0-rc2/envs/skylab-1.0.0-gnu-10.2.0/install/gcc/10.2.0/ecbuild-3.6.5-synmrk4/share/ecbuild/cmake/ecbuild_project.cmake:106 (_project):
  VERSION "3.0.6-jedi" format invalid.
Call Stack (most recent call first):
  gsw/CMakeLists.txt:3 (project)

This fixed the issue.