### PR TITLE
Bump version in CMakeLists.txt to 3.0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.12 )
 
-project( gsw VERSION 3.0.6 LANGUAGES Fortran )
+project( gsw VERSION 3.0.7 LANGUAGES Fortran )
 
 ## Ecbuild integration
 find_package( ecbuild QUIET )


### PR DESCRIPTION
## Description

Bump version in CMakeLists.txt to 3.0.7 so that we can create tag v3.07 for the skylab-2.0.0 release.